### PR TITLE
Extend Service instead of Object for services

### DIFF
--- a/app/services/csrf.js
+++ b/app/services/csrf.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   onAjaxComplete: function() {
     var _this = this;
     this.fetchToken();


### PR DESCRIPTION
It's for removing following deprecation warning in Ember.js 1.13

```
DEPRECATION: In Ember 2.0 service factories must have an `isServiceFactory` property set to true. You registered (unknown mixin) as a service factory. Either add the `isServiceFactory` property to this factory or extend from Ember.Service.
```
